### PR TITLE
Improved array column batch inserting.

### DIFF
--- a/ClickHouse.Ado/Impl/ColumnTypes/ArrayColumnType.cs
+++ b/ClickHouse.Ado/Impl/ColumnTypes/ArrayColumnType.cs
@@ -6,7 +6,7 @@ using ClickHouse.Ado.Impl.ATG.Insert;
 
 namespace ClickHouse.Ado.Impl.ColumnTypes
 {
-    internal class ArrayColumnType : ColumnType
+    internal class ArrayColumnType<T> : ColumnType
     {
         public ArrayColumnType(ColumnType innerType)
         {
@@ -79,9 +79,9 @@ namespace ClickHouse.Ado.Impl.ColumnTypes
         public override void ValuesFromConst(IEnumerable objects)
         {
             var offsets = new List<ulong>();
-            var itemsPlain = new List<object>();
+            var itemsPlain = new List<T>();
             ulong currentOffset = 0;
-            foreach (var item in objects.Cast<IEnumerable<object>>())
+            foreach (var item in objects.Cast<IEnumerable<T>>())
             {
                 currentOffset += (ulong)item.Count();
                 offsets.Add(currentOffset);

--- a/ClickHouse.Ado/Impl/ColumnTypes/ColumnType.cs
+++ b/ClickHouse.Ado/Impl/ColumnTypes/ColumnType.cs
@@ -58,8 +58,36 @@ namespace ClickHouse.Ado.Impl.ColumnTypes
                         return new NullableColumnType(Create(m.Groups["inner"].Value));
                     case "Array":
                         if (m.Groups["inner"].Value == "Null")
-                            return new ArrayColumnType(new NullableColumnType(new SimpleColumnType<byte>()));
-                        return new ArrayColumnType(Create(m.Groups["inner"].Value));
+                            return new ArrayColumnType<object>(new NullableColumnType(new SimpleColumnType<byte>()));
+                        else if (m.Groups["inner"].Value == "Uint8")
+                            return new ArrayColumnType<byte>(Create(m.Groups["inner"].Value));
+                        else if (m.Groups["inner"].Value == "Int8")
+                            return new ArrayColumnType<sbyte>(Create(m.Groups["inner"].Value));
+                        else if (m.Groups["inner"].Value == "UInt16")
+                            return new ArrayColumnType<ushort>(Create(m.Groups["inner"].Value));
+                        else if (m.Groups["inner"].Value == "Int16")
+                            return new ArrayColumnType<short>(Create(m.Groups["inner"].Value));
+                        else if (m.Groups["inner"].Value == "UInt32")
+                            return new ArrayColumnType<uint>(Create(m.Groups["inner"].Value));
+                        else if (m.Groups["inner"].Value == "Int32")
+                            return new ArrayColumnType<int>(Create(m.Groups["inner"].Value));
+                        else if (m.Groups["inner"].Value == "UInt64")
+                            return new ArrayColumnType<ulong>(Create(m.Groups["inner"].Value));
+                        else if (m.Groups["inner"].Value == "Int64")
+                            return new ArrayColumnType<long>(Create(m.Groups["inner"].Value));
+                        else if (m.Groups["inner"].Value == "Float64")
+                            return new ArrayColumnType<double>(Create(m.Groups["inner"].Value));
+                        else if (m.Groups["inner"].Value == "Float32")
+                            return new ArrayColumnType<float>(Create(m.Groups["inner"].Value));
+                        else if (m.Groups["inner"].Value == "Decimal")
+                            return new ArrayColumnType<decimal>(Create(m.Groups["inner"].Value));
+                        else if (m.Groups["inner"].Value == "Boolean")
+                            return new ArrayColumnType<bool>(Create(m.Groups["inner"].Value));
+                        else if (m.Groups["inner"].Value == "DateTime")
+                            return new ArrayColumnType<DateTime>(Create(m.Groups["inner"].Value));
+                        else if (m.Groups["inner"].Value == "String")
+                            return new ArrayColumnType<string>(Create(m.Groups["inner"].Value));
+                        return new ArrayColumnType<object>(Create(m.Groups["inner"].Value));
                     case "AggregateFunction":
                         //See ClickHouse\dbms\src\DataTypes\DataTypeFactory.cpp:128
                         throw new NotImplementedException($"AggregateFunction({m.Groups["inner"].Value}) column type is not supported");

--- a/ClickHouse.Test/SimpleTests.cs
+++ b/ClickHouse.Test/SimpleTests.cs
@@ -136,6 +136,33 @@ namespace ClickHouse.Test
         }
 
         [TestMethod]
+        public void InsertIntArray()
+        {
+            using (var cnn = GetConnection())
+            {
+                // Create temp table
+                using (var cmd = cnn.CreateCommand("DROP TABLE IF EXISTS test_InsertIntArray"))
+                    cmd.ExecuteNonQuery();
+                using (var cmd = cnn.CreateCommand("CREATE TABLE IF NOT EXISTS test_InsertIntArray(date Date default today(), ints Array(integer)) ENGINE=MergeTree(date,(date), 8192)"))
+                    cmd.ExecuteNonQuery();
+                using (var cmd = cnn.CreateCommand("INSERT INTO test_InsertIntArray(ints) VALUES @bulk"))
+                {
+                    cmd.Parameters.Add(new ClickHouseParameter
+                    {
+                        DbType = DbType.Object,
+                        ParameterName = "bulk",
+                        Value = new[]
+                        {
+                            new object[] {new int[] {2, 4}},
+                            new object[] {new int[0]},
+                        }
+                    });
+                    cmd.ExecuteNonQuery();
+                }
+            }
+        }
+
+        [TestMethod]
         public void TestPerfromance()
         {
             using (var cnn = GetConnection())


### PR DESCRIPTION
Fixed error - Can't cast IEnumerable<int> to Enumerable<object>

Changes:
- ArrayColumnType.cs is tranformed to generic class
- ColumnType.cs  - added array type switching
- SimpleTests.cs - added new test InsertIntArray()
